### PR TITLE
Correct spelling for Tuesday

### DIFF
--- a/App/Client/App.da.resx
+++ b/App/Client/App.da.resx
@@ -226,7 +226,7 @@
   <data name="Sunday" xml:space="preserve">
     <value>Søndag</value>
   </data>
-  <data name="Thuesday" xml:space="preserve">
+  <data name="Tuesday" xml:space="preserve">
     <value>Tirsdag</value>
   </data>
   <data name="Thursday" xml:space="preserve">

--- a/App/Client/App.de.resx
+++ b/App/Client/App.de.resx
@@ -237,7 +237,7 @@
   <data name="Sunday" xml:space="preserve">
     <value>Sonntag</value>
   </data>
-  <data name="Thuesday" xml:space="preserve">
+  <data name="Tuesday" xml:space="preserve">
     <value>Dienstag</value>
   </data>
   <data name="Thursday" xml:space="preserve">

--- a/App/Client/App.no.resx
+++ b/App/Client/App.no.resx
@@ -237,7 +237,7 @@
   <data name="Sunday" xml:space="preserve">
     <value>Søndag</value>
   </data>
-  <data name="Thuesday" xml:space="preserve">
+  <data name="Tuesday" xml:space="preserve">
     <value>Tirsdag</value>
   </data>
   <data name="Thursday" xml:space="preserve">

--- a/App/Client/App.resx
+++ b/App/Client/App.resx
@@ -246,8 +246,8 @@
   <data name="Sunday" xml:space="preserve">
     <value>Sunday</value>
   </data>
-  <data name="Thuesday" xml:space="preserve">
-    <value>Thuesday</value>
+  <data name="Tuesday" xml:space="preserve">
+    <value>Tuesday</value>
   </data>
   <data name="Thursday" xml:space="preserve">
     <value>Thursday</value>

--- a/App/Client/App.sv.resx
+++ b/App/Client/App.sv.resx
@@ -237,7 +237,7 @@
   <data name="Sunday" xml:space="preserve">
     <value>Söndag</value>
   </data>
-  <data name="Thuesday" xml:space="preserve">
+  <data name="Tuesday" xml:space="preserve">
     <value>Tisdag</value>
   </data>
   <data name="Thursday" xml:space="preserve">

--- a/Clock.Server/ClockServer.cs
+++ b/Clock.Server/ClockServer.cs
@@ -244,7 +244,7 @@ namespace Tellurian.Trains.Clocks.Server
     {
         NoDay,
         Monday,
-        Thuesday,
+        Tuesday,
         Wednesday,
         Thursday,
         Friday,


### PR DESCRIPTION
It was incorrectly spelled as Thuesday. I adapted both the enum value and the English 'translation'.