### PR TITLE
Extend sidebar width to fit English title and text

### DIFF
--- a/App/Client/wwwroot/css/app.css
+++ b/App/Client/wwwroot/css/app.css
@@ -224,7 +224,7 @@ app {
     }
 
     .sidebar {
-        width: 250px;
+        width: 350px;
         height: 100vh;
         position: sticky;
         top: 0;


### PR DESCRIPTION
The width of the sidebar was 250 pixels, that was insufficient to show the title and it caused the 'Clock Administration' text to wrap. This fix extends the width to 350 pixels which resolves both issues.