### PR TITLE
Translation to German improved

### DIFF
--- a/App/Client/App.de.resx
+++ b/App/Client/App.de.resx
@@ -157,7 +157,7 @@
     <value>Spiel ist angehalten für</value>
   </data>
   <data name="GameIsResumedAtTime" xml:space="preserve">
-    <value>Das Spiel wird um {0} fortgesetzt</value>
+    <value>Das Spiel wird um {0} Uhr fortgesetzt</value>
   </data>
   <data name="GameOver" xml:space="preserve">
     <value>Das Spiel ist zu Ende!</value>
@@ -175,7 +175,7 @@
     <value>Mittagessen</value>
   </data>
   <data name="Meeting" xml:space="preserve">
-    <value>Besprechung</value>
+    <value>Modultreffen</value>
   </data>
   <data name="Message" xml:space="preserve">
     <value>Nachricht</value>
@@ -193,13 +193,13 @@
     <value>Kein Grund</value>
   </data>
   <data name="OnlyAdministratorCanStart" xml:space="preserve">
-    <value>Nur der Administrator kann neu starten</value>
+    <value>Nur der Administrator kann starten</value>
   </data>
   <data name="Other" xml:space="preserve">
     <value>Anderer Grund</value>
   </data>
   <data name="PauseAtRealTime" xml:space="preserve">
-    <value>Pause in Echtzeit</value>
+    <value>Pause zur Echtzeit</value>
   </data>
   <data name="Realclock" xml:space="preserve">
     <value>Echtzeituhr</value>
@@ -274,7 +274,7 @@
     <value>Problem Stationskontrollsystem</value>
   </data>
   <data name="PointProblem" xml:space="preserve">
-    <value>Problem Wechseln</value>
+    <value>Problem: Weichen</value>
   </data>
   <data name="TrackProblem" xml:space="preserve">
     <value>Problem: Gleis</value>
@@ -286,10 +286,10 @@
     <value>Booster-Fehler</value>
   </data>
   <data name="LocoNetError" xml:space="preserve">
-    <value>LocoNet Fehler</value>
+    <value>LocoNet-Fehler</value>
   </data>
   <data name="CentralError" xml:space="preserve">
-    <value>Fehler in der digitalen Zentrale</value>
+    <value>Fehler in der Digitalzentrale</value>
   </data>
   <data name="Delays" xml:space="preserve">
     <value>Verzögerungen</value>
@@ -332,7 +332,7 @@ Uhreinstellungen zu ändern</value>
     <value>Eine Spielstunde dauert {0:F0} Minuten</value>
   </data>
   <data name="GameEndsAtTime" xml:space="preserve">
-    <value>Das Spiel endet um {0}, Echtzeit {1}</value>
+    <value>Das Spiel endet um {0} Uhr, Echtzeit {1} Uhr</value>
   </data>
   <data name="Coffe" xml:space="preserve">
     <value>Kaffeepause</value>

--- a/App/Server/Markdown/About.de.md
+++ b/App/Server/Markdown/About.de.md
@@ -1,6 +1,6 @@
 ﻿Die App wurde von der schwedischen Firma Tellurian Interactive AB entwickelt.
 
-Die App wird als Open Source auf GitHub veröffentlicht. Sie können zur Entwicklung beitragen und können gerne Pull-Anfragen einreichen.
+Die App wird als Open Source auf GitHub veröffentlicht. Sie können zur Entwicklung beitragen und können gerne Pull-Requests einreichen.
 
 Die App basiert auf Microsoft .Net 5.0 und Blazor Webassembly, beide Open Source auf GitHub. 
 Die Entwicklung erfolgt mit der kostenlosen Microsoft Visual Studio Community Edition.

--- a/App/Server/Markdown/Index.de.md
+++ b/App/Server/Markdown/Index.de.md
@@ -8,9 +8,9 @@ Laden Sie dann die App in Ihrem Webbrowser neu.
 
 ### Wo ist die Uhr?
 Es gibt immer die *Demo* Uhr zum Spielen.
-Die *Demo*-Uhr wird jedoch nicht bei Besprechungen verwendet.
+Die *Demo*-Uhr wird jedoch nicht bei Modultreffen verwendet.
 
-Der Administrator hat normalerweise eine bestimmte Uhr für die Besprechung eingerichtet.
+Der Administrator hat normalerweise eine bestimmte Uhr für das Modultreffen eingerichtet.
 1. Fragen Sie den Administrator nach der Uhr *Name* und optional nach dem *Benutzerpasswort*.
 2. Wählen Sie im Menü *Einstellungen*, geben Sie diese Informationen ein und klicken Sie auf *Speichern*.
 3. Wählen Sie im Menü *Uhr* und Sie sehen die Besprechungsuhr.

--- a/App/Server/Markdown/Settings.de.md
+++ b/App/Server/Markdown/Settings.de.md
@@ -1,6 +1,6 @@
-﻿Eine Registrierung ist erforderlich, wenn Sie die Uhr über Ihre App stoppen und starten möchten. Sonst kümmere dich nicht darum.
+﻿Eine Registrierung ist erforderlich, wenn Sie die Uhr über Ihre App stoppen und starten möchten. Sonst brauchen Sie sich nicht darum zu kümmern.
 
-Wenn Ihr Gerät an einer Station stationär ist, registrieren Sie Ihren Stationsnamen. Andernfalls registrieren Sie sich mit einem persönlichen Namen, der den Teilnehmern des Meetings bekannt ist.
+Wenn Ihr Gerät fest an einer Station aufgestellt ist, registrieren Sie Ihren Stationsnamen. Andernfalls registrieren Sie sich mit einem persönlichen Namen, der den Teilnehmern des Meetings bekannt ist.
 
 Registrieren Sie auch ein Passwort, wenn der Administrator dies benötigt, um die Uhr zu stoppen und zu starten.
 


### PR DESCRIPTION
Hej Stefan,

jag har filat lite på den tyska översättning. Framförallt "Besprechunge" stack i ögat (och kanske var det jag som missledd dog där) men du syftar nog på Fremo-Träffar och dyl, tror jag.

En fundering - på formell Tyska använder man ju "Sie" istället för "Du". I hobbykretsar är dock "Du" mycket vanlig, och framförallt förknippas "Du" i offentliga miljöer i Tyskland mycket med Sverige, tack vare IKEA reklamen. Eftersom snabbklockan är ett svensk produkt skulle "Du" passar mycket bra.

Vad tycks?

/Franz